### PR TITLE
Fix multiple definitions linker error

### DIFF
--- a/NativeStuffs/libusbkit/libusbkit.h
+++ b/NativeStuffs/libusbkit/libusbkit.h
@@ -27,7 +27,7 @@ typedef struct UKDevice_INFO {
     char buf[0x2C000];
 } UKDevice_SHAtter;
 
-UKDevice_SHAtter SHAtter_user;
+extern UKDevice_SHAtter SHAtter_user;
 
 
 typedef struct UKDevice {

--- a/NativeStuffs/libusbkit/libusbkit.m
+++ b/NativeStuffs/libusbkit/libusbkit.m
@@ -1,5 +1,5 @@
 //
-//  libusbkit.c
+//  libusbkit.m
 //  libusbkit
 //
 //  Created by Steven De Franco on 2/7/13.
@@ -25,6 +25,7 @@ static io_iterator_t			gAddedIter; //need different io iterators to keep track o
 static io_iterator_t            gRemovedIter;
 static IONotificationPortRef	gNotifyPort; //our notification port keeping track of removing and adding devices.
 
+UKDevice_SHAtter SHAtter_user;
 
 UKDevice* _pending = NULL;
 int SEARCHING_FOR_NEW_SHATTER_DEVICE = 0;


### PR DESCRIPTION
Fix multiple definitions linker error.

Defines SHAtter_user in the source file rather than the header file, since the header file is included from multiple files and causes a linker error due to multiple definitions.