### PR TITLE
Fix hangs while waiting for DFU mode.

### DIFF
--- a/NativeStuffs/libusbkit/libusbkit.m
+++ b/NativeStuffs/libusbkit/libusbkit.m
@@ -402,7 +402,7 @@ void device_attached(void * refCon, io_iterator_t iterator) {
         if (ret != 0) {
             
             _error("IOCreatePlugInInterfaceForService", ret);
-            return;
+            continue;
         }
         
         result = (*pluginInterface)->QueryInterface(pluginInterface,
@@ -414,7 +414,7 @@ void device_attached(void * refCon, io_iterator_t iterator) {
         if (result != 0) {
             
             _error("QueryInterface", ret);
-            return;
+            continue;
         }
         
         (*_dev)->GetDeviceVendor(_dev, &vendorID);


### PR DESCRIPTION
All entries in the iterator passed to device_attached() must be consumed for it to fire again. Change error handling to continue instead of return so that device_attached() will be called again once the device reconnects after booting to DFU mode.